### PR TITLE
fixed fahrenheit to celsius conversion; 0.5 steps

### DIFF
--- a/src/accessory.ts
+++ b/src/accessory.ts
@@ -147,7 +147,8 @@ export class DaikinCloudAirConditioningAccessory {
     }
 
     async handleCoolingThresholdTemperatureSet(value: CharacteristicValue) {
-        const temperature = value as number;
+        const temperature = Math.round(value*2)/2 as number;
+        // const temperature = value as number;
         this.platform.log.info(`[${this.name}] SET CoolingThresholdTemperature, temperature to: ${temperature}`);
         await this.accessory.context.device.setData('climateControl', 'temperatureControl', '/operationModes/cooling/setpoints/roomTemperature', temperature);
         await this.accessory.context.device.updateData();
@@ -176,7 +177,8 @@ export class DaikinCloudAirConditioningAccessory {
     }
 
     async handleHeatingThresholdTemperatureSet(value: CharacteristicValue) {
-        const temperature = value as number;
+        const temperature = Math.round(value*2)/2 as number;
+        // const temperature = value as number;
         this.platform.log.info(`[${this.name}] SET HeatingThresholdTemperature, temperature to: ${temperature}`);
         await this.accessory.context.device.setData('climateControl', 'temperatureControl', '/operationModes/heating/setpoints/roomTemperature', temperature);
         await this.accessory.context.device.updateData();


### PR DESCRIPTION
When converting temperature from Fahrenheit to Celsius, HomeKit would try to set temperatures that are not accepted by Daikin. Updated 2 lines of code (`handleCoolingThresholdTemperatureSet` and `handleHeatingThresholdTemperatureSet`) to round off to the nearest 0.5. Doesn't affect users who use HomeKit in Celsius but users trying to set temperature in Fahrenheit would crash the plugin.