### PR TITLE
fix: stop one air conditioner from turning on all of them

### DIFF
--- a/src/daikinAccessory.ts
+++ b/src/daikinAccessory.ts
@@ -15,10 +15,23 @@ export class daikinAccessory {
 
         this.printDeviceInfo();
 
-        this.accessory.getService(this.platform.Service.AccessoryInformation)!
+        const serialNumberData = accessory.context.device.getData(this.gatewayManagementPointId, 'serialNumber', undefined);
+        // Some adapters (e.g. BRP069A8x/B4x air-to-air units) don't report a serialNumber. Falling back to a
+        // constant string would give every such accessory an identical SerialNumber, which makes the Apple Home
+        // app treat them as the same physical accessory and mirror commands across them (e.g. turning on one AC
+        // turns on all of them). The device id is unique per gateway-device, so use it as a stable unique fallback.
+        const serialNumber: string = serialNumberData ? serialNumberData.value : accessory.context.device.getId();
+
+        const firmwareData = accessory.context.device.getData(this.gatewayManagementPointId, 'firmwareVersion', undefined);
+
+        const accessoryInformation = this.accessory.getService(this.platform.Service.AccessoryInformation)!
             .setCharacteristic(this.platform.Characteristic.Manufacturer, 'Daikin')
             .setCharacteristic(this.platform.Characteristic.Model, accessory.context.device.getData(this.gatewayManagementPointId, 'modelInfo', undefined).value)
-            .setCharacteristic(this.platform.Characteristic.SerialNumber, accessory.context.device.getData(this.gatewayManagementPointId, 'serialNumber', undefined) ? accessory.context.device.getData(this.gatewayManagementPointId, 'serialNumber', undefined).value : 'NOT_AVAILABLE');
+            .setCharacteristic(this.platform.Characteristic.SerialNumber, serialNumber);
+
+        if (firmwareData) {
+            accessoryInformation.setCharacteristic(this.platform.Characteristic.FirmwareRevision, firmwareData.value);
+        }
 
         this.accessory.context.device.on('updated', () => {
             this.platform.log.debug(`[API Syncing] Updated ${this.accessory.displayName} (${this.accessory.UUID}), LastUpdated: ${this.accessory.context.device.getLastUpdated()}`);

--- a/src/repository/daikinCloudRepo.ts
+++ b/src/repository/daikinCloudRepo.ts
@@ -1,19 +1,23 @@
 export class DaikinCloudRepo {
     static maskSensitiveCloudDeviceData(cloudDeviceDetails) {
-        return {
-            managementPoints: cloudDeviceDetails.managementPoints.map(managementPoint => {
-                if (managementPoint.ipAddress) managementPoint.ipAddress.value = 'REDACTED';
-                if (managementPoint.macAddress) managementPoint.macAddress.value = 'REDACTED';
-                if (managementPoint.ssid) managementPoint.ssid.value = 'REDACTED';
-                if (managementPoint.serialNumber) managementPoint.serialNumber.value = 'REDACTED';
-                if (managementPoint.wifiConnectionSSID) managementPoint.wifiConnectionSSID.value = 'REDACTED';
-                if (managementPoint.consumptionData) managementPoint.consumptionData = 'REDACTED';
-                if (managementPoint.schedule) managementPoint.schedule = 'REDACTED';
-                if (managementPoint.consumptionData) managementPoint.consumptionData = 'REDACTED';
+        // IMPORTANT: deep-clone before masking. This used to mask in place, which mutated the live device cache:
+        // serialNumber.value was overwritten with 'REDACTED' for every device just before its accessory was created
+        // (called from createDevices). All accessories then got the identical SerialNumber 'REDACTED', which makes the
+        // Apple Home app treat them as one physical accessory and mirror commands (turning on one AC turned on all).
+        const masked = structuredClone(cloudDeviceDetails);
 
-                return managementPoint;
-            }),
-            ...cloudDeviceDetails,
-        };
+        masked.managementPoints = (masked.managementPoints ?? []).map(managementPoint => {
+            if (managementPoint.ipAddress) managementPoint.ipAddress.value = 'REDACTED';
+            if (managementPoint.macAddress) managementPoint.macAddress.value = 'REDACTED';
+            if (managementPoint.ssid) managementPoint.ssid.value = 'REDACTED';
+            if (managementPoint.serialNumber) managementPoint.serialNumber.value = 'REDACTED';
+            if (managementPoint.wifiConnectionSSID) managementPoint.wifiConnectionSSID.value = 'REDACTED';
+            if (managementPoint.consumptionData) managementPoint.consumptionData = 'REDACTED';
+            if (managementPoint.schedule) managementPoint.schedule = 'REDACTED';
+
+            return managementPoint;
+        });
+
+        return masked;
     }
 }

--- a/test/repository/daikinCloud.test.ts
+++ b/test/repository/daikinCloud.test.ts
@@ -8,5 +8,23 @@ test.each<Array<string | any>>([
     ['dx23', dx23Airco],
     ['altherma', althermaHeatPump],
 ])('Clean cloud device data for %s device', (name, deviceJson) => {
-    expect(DaikinCloudRepo.maskSensitiveCloudDeviceData(deviceJson)).toMatchSnapshot();
+    expect(DaikinCloudRepo.maskSensitiveCloudDeviceData(structuredClone(deviceJson))).toMatchSnapshot();
+});
+
+// Regression test for the "turning on one AC turns on all" bug: masking must NOT mutate the input, otherwise the live
+// device cache gets its real serialNumber overwritten with 'REDACTED' for every device, giving them identical serials.
+test('does not mutate the original device data', () => {
+    const device = {
+        id: 'device-1',
+        managementPoints: [
+            {embeddedId: 'gateway', serialNumber: {value: 'REAL-SERIAL-123'}, macAddress: {value: 'AA:BB:CC'}},
+        ],
+    };
+
+    const masked = DaikinCloudRepo.maskSensitiveCloudDeviceData(device);
+
+    // The masked copy is redacted...
+    expect(masked.managementPoints[0].serialNumber.value).toBe('REDACTED');
+    // ...but the original is untouched, so each accessory keeps its own real serial.
+    expect(device.managementPoints[0].serialNumber.value).toBe('REAL-SERIAL-123');
 });

--- a/test/serialNumber.test.ts
+++ b/test/serialNumber.test.ts
@@ -1,0 +1,48 @@
+import {PlatformAccessory} from 'homebridge/lib/platformAccessory';
+import {DaikinCloudAccessoryContext, DaikinCloudPlatform} from '../src/platform';
+import {MockPlatformConfig} from './mocks';
+import {daikinAirConditioningAccessory} from '../src/daikinAirConditioningAccessory';
+import {DaikinCloudDevice} from 'daikin-controller-cloud/dist/device';
+import {OnectaClient} from 'daikin-controller-cloud/dist/onecta/oidc-client';
+import {dx23Airco} from './fixtures/dx23-airco';
+import {dx23Airco2} from './fixtures/dx23-airco-2';
+
+import {HomebridgeAPI} from 'homebridge/lib/api.js';
+import {Logger} from 'homebridge/lib/logger.js';
+
+function buildAccessory(deviceJson: object) {
+    const device = new DaikinCloudDevice(structuredClone(deviceJson), ({requestResource: async () => true}) as unknown as OnectaClient);
+    const config = new MockPlatformConfig(true);
+    const api = new HomebridgeAPI();
+    const uuid = api.hap.uuid.generate(device.getId());
+    const accessory = new api.platformAccessory('NAME_FOR_TEST', uuid);
+    accessory.context['device'] = device;
+
+    new daikinAirConditioningAccessory(new DaikinCloudPlatform(new Logger(), config, api), accessory as unknown as PlatformAccessory<DaikinCloudAccessoryContext>);
+
+    const serialNumber = accessory
+        .getService(api.hap.Service.AccessoryInformation)!
+        .getCharacteristic(api.hap.Characteristic.SerialNumber).value;
+
+    return {device, serialNumber};
+}
+
+// Regression test for the "turning on one AC turns on all ACs" bug.
+//
+// Several air-to-air adapters (e.g. BRP069A8x/B4x) don't report a serialNumber. The plugin used to fall back to
+// the constant string 'NOT_AVAILABLE', so every such accessory ended up with an identical SerialNumber. The Apple
+// Home app then treats accessories with the same SerialNumber + Manufacturer as the same physical accessory and
+// mirrors commands across them. The fix falls back to the (unique) device id instead.
+describe('AccessoryInformation SerialNumber', () => {
+    test('falls back to the unique device id when the device does not report a serialNumber', () => {
+        const {device, serialNumber} = buildAccessory(dx23Airco);
+        expect(serialNumber).toBe(device.getId());
+        expect(serialNumber).not.toBe('NOT_AVAILABLE');
+    });
+
+    test('two devices without a serialNumber get distinct SerialNumbers', () => {
+        const a = buildAccessory(dx23Airco);
+        const b = buildAccessory(dx23Airco2);
+        expect(a.serialNumber).not.toBe(b.serialNumber);
+    });
+});


### PR DESCRIPTION
maskSensitiveCloudDeviceData redacted serialNumber.value in place, mutating the live device cache. It runs for every device in createDevices just before each accessory reads its serial, so all accessories ended up with the same SerialNumber ('REDACTED'). The Apple Home app then treats devices with an identical SerialNumber + Manufacturer as one physical accessory and mirrors commands, so turning on one AC turned on all of them.

Deep-clone the device data before masking so the real, unique serial numbers are preserved. As an extra safeguard, fall back to the unique device id (rather than a constant) when a device genuinely reports no serial number, and expose the firmware revision while we are in AccessoryInformation.