### PR TITLE
fix: set accessory category so Siri recognises the unit as an air con…

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -138,9 +138,18 @@ export class DaikinCloudPlatform implements DynamicPlatformPlugin {
                     return;
                 }
 
+                // The category tells the Home app and Siri what kind of device this is. Without it an air conditioner
+                // stays a generic "other" device, which Siri does not recognise as a climate device, so "set the air
+                // conditioner to 19 degrees" can get routed to another thermostat in the home. We pass it to the
+                // accessory constructor (the canonical way) for new accessories and re-assert it on restored ones.
+                const category = deviceModel === 'Altherma'
+                    ? this.api.hap.Categories.THERMOSTAT
+                    : this.api.hap.Categories.AIR_CONDITIONER;
+
                 if (existingAccessory) {
                     this.log.info('[Platform] Restoring existing accessory from cache:', existingAccessory.displayName);
                     existingAccessory.context.device = device;
+                    existingAccessory.category = category;
                     this.api.updatePlatformAccessories([existingAccessory]);
 
                     if (deviceModel === 'Altherma') {
@@ -153,7 +162,7 @@ export class DaikinCloudPlatform implements DynamicPlatformPlugin {
                     const climateControlEmbeddedId = device.desc.managementPoints.find(mp => mp.managementPointType === 'climateControl')?.embeddedId;
                     const name: string = device.getData(climateControlEmbeddedId, 'name', undefined).value;
                     this.log.info('[Platform] Adding new accessory, deviceModel:', StringUtils.isEmpty(name) ? deviceModel : name);
-                    const accessory = new this.api.platformAccessory<DaikinCloudAccessoryContext>(StringUtils.isEmpty(name) ? deviceModel : name, uuid);
+                    const accessory = new this.api.platformAccessory<DaikinCloudAccessoryContext>(StringUtils.isEmpty(name) ? deviceModel : name, uuid, category);
                     accessory.context.device = device;
 
                     if (deviceModel === 'Altherma') {


### PR DESCRIPTION
Hoi Jeroen,

Een tweede verbetering uit mijn fork.

## Probleem
De airco-accessoires krijgen geen `category`, dus ze blijven voor HomeKit een
generiek "Other"-apparaat. Siri behandelt ze daardoor niet als klimaat-apparaat.
Gevolg: een commando als "zet de airco op 19 graden" kan bij een ándere
thermostaat in huis terechtkomen in plaats van bij de Daikin-unit.

## Fix
Zet de category op `AIR_CONDITIONER` (air-to-air) of `THERMOSTAT` (Altherma).
Voor nieuwe accessoires geef ik 'm mee aan de constructor (de category kan alleen
bij het aanmaken gezet worden, niet achteraf op een bestaande); op herstelde
accessoires zet ik 'm opnieuw.

Live getest met 4 BRP069C4x-units: hierna herkent Siri ze als airco's en gaan
"zet de airco ..."-commando's naar de juiste unit.

Groet, Jasper